### PR TITLE
Feat/refactor imran

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func main() {
 
 	mux.Handle("GET /products", http.HandlerFunc(getProducts))
 	mux.Handle("POST /products", http.HandlerFunc(createProduct))
+	mux.Handle("OPTIONS /products", http.HandlerFunc(createProduct))
 
 	fmt.Println("Server is running on port 3000")
 	err := http.ListenAndServe(":3000", mux)

--- a/main.go
+++ b/main.go
@@ -43,22 +43,12 @@ var ProductList []Product
 
 func getProducts(w http.ResponseWriter, r *http.Request) {
 	handleCors(w)
-
-	if r.Method != http.MethodGet {
-		http.Error(w, "Please give me GET request", http.StatusBadRequest)
-		return
-	}
 	sendData(w, ProductList, http.StatusOK)
 }
 
 func createProduct(w http.ResponseWriter, r *http.Request) {
 	handleCors(w)
 	handlePreflightReq(w, r)
-
-	if r.Method != http.MethodPost {
-		http.Error(w, "Please Give me POST request", http.StatusBadRequest)
-		return
-	}
 
 	newProduct := Product{}
 
@@ -81,8 +71,8 @@ func createProduct(w http.ResponseWriter, r *http.Request) {
 func main() {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/products", getProducts)
-	mux.HandleFunc("/create-product", createProduct)
+	mux.Handle("GET /products", http.HandlerFunc(getProducts))
+	mux.Handle("POST /products", http.HandlerFunc(createProduct))
 
 	fmt.Println("Server is running on port 3000")
 	err := http.ListenAndServe(":3000", mux)


### PR DESCRIPTION
This pull request refactors the HTTP route handling in `main.go` to use the newer pattern-based routing introduced in Go 1.21, and removes explicit HTTP method checks from the handler functions. This results in cleaner and more idiomatic route definitions and handler logic.

**Routing improvements:**

* Updated the route registration to use pattern-based handlers (`mux.Handle("METHOD /path", ...)`) instead of the older `HandleFunc` approach, allowing for direct mapping of HTTP methods to handlers. Now, `GET`, `POST`, and `OPTIONS` requests to `/products` are handled by their respective functions.

**Handler simplification:**

* Removed explicit HTTP method checks from the `getProducts` and `createProduct` handlers, since the routing now ensures only the correct methods reach each handler, simplifying the code and reducing redundancy.